### PR TITLE
[Minor] Fix boundary issue in #1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue-project",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vue-project",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "ant-design-vue": "^3.2.20",
         "brace": "^0.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-project",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/public/js/photopea.js
+++ b/public/js/photopea.js
@@ -145,9 +145,10 @@ function cropSelectedRegion(maskBlur) {
     const layer = doc.activeLayer;
 
     layer.rasterize(RasterizeType.ENTIRELAYER);
-    doc.selection.expand(maskBlur);
-    doc.selection.feather(maskBlur);
-
+    if (maskBlur) {
+        doc.selection.expand(maskBlur);
+        doc.selection.feather(maskBlur);
+    }
     // Clear everything outside selection.
     doc.selection.invert();
     doc.selection.clear();

--- a/public/js/photopea.js
+++ b/public/js/photopea.js
@@ -108,7 +108,7 @@ function pasteImageAsNewLayer(base64image) {
 // Translate the newly added layer if the new layer has been added.
 // Note: we cannot get layer bounds when a selection is active. So the resize and
 // translation are all based on payload calculations.
-function translateIfNewLayerAdded(layerCount, bounds, scaleRatio, layerName) {
+function translateIfNewLayerAdded(layerCount, bounds, scaleX, scaleY, layerName) {
     if (app.activeDocument.layers.length === layerCount) {
         app.echoToOE("fail");
         return;
@@ -117,8 +117,8 @@ function translateIfNewLayerAdded(layerCount, bounds, scaleRatio, layerName) {
     const doc = app.activeDocument;
     const layer = doc.activeLayer;
     layer.resize(
-        (1 / scaleRatio) * 100,
-        (1 / scaleRatio) * 100,
+        (1 / scaleX) * 100,
+        (1 / scaleY) * 100,
         AnchorPosition.MIDDLECENTER
     );
 

--- a/public/js/photopea.js
+++ b/public/js/photopea.js
@@ -151,6 +151,7 @@ function cropSelectedRegion(maskBlur) {
     // Clear everything outside selection.
     doc.selection.invert();
     doc.selection.clear();
+    doc.selection.invert();
     app.echoToOE("success");
 }
 

--- a/public/js/photopea.js
+++ b/public/js/photopea.js
@@ -108,7 +108,7 @@ function pasteImageAsNewLayer(base64image) {
 // Translate the newly added layer if the new layer has been added.
 // Note: we cannot get layer bounds when a selection is active. So the resize and
 // translation are all based on payload calculations.
-function translateIfNewLayerAdded(layerCount, bounds, scaleX, scaleY, layerName) {
+function translateIfNewLayerAdded(layerCount, bounds, layerName) {
     if (app.activeDocument.layers.length === layerCount) {
         app.echoToOE("fail");
         return;
@@ -116,11 +116,6 @@ function translateIfNewLayerAdded(layerCount, bounds, scaleX, scaleY, layerName)
 
     const doc = app.activeDocument;
     const layer = doc.activeLayer;
-    layer.resize(
-        (1 / scaleX) * 100,
-        (1 / scaleY) * 100,
-        AnchorPosition.MIDDLECENTER
-    );
 
     const width = bounds[2] - bounds[0];
     const height = bounds[3] - bounds[1];

--- a/public/js/photopea.js
+++ b/public/js/photopea.js
@@ -308,7 +308,18 @@ function exportLayersWithNames(layerNames, format) {
     exportSelectedLayerOnly(format, layerSelector);
 }
 
-function fillSelectionWithBlackInNewLayer(layerName) {
+function selectBound(bound) {
+    const doc = app.activeDocument;
+    const bounds = [
+        [bound[0], bound[1]], 
+        [bound[2], bound[1]], 
+        [bound[2], bound[3]], 
+        [bound[0], bound[3]],
+    ];
+    doc.selection.select(bounds, SelectionType.REPLACE, 0, false);
+}
+
+function createRefRangePlaceholder(bound, layerName) {
     if (!hasSelection()) {
         alert("No selection!");
         app.echoToOE("error");
@@ -320,13 +331,15 @@ function fillSelectionWithBlackInNewLayer(layerName) {
     // Create a temp layer.
     const newLayer = app.activeDocument.artLayers.add();
     newLayer.name = layerName;
+    newLayer.opacity = 30;
 
     const blackColor = new SolidColor();
     blackColor.rgb.red = 0;
     blackColor.rgb.green = 0;
     blackColor.rgb.blue = 0;
 
-    // Fill with the foreground color and deselect.
+    // Fill with the foreground color
+    selectBound(bound);
     app.activeDocument.selection.fill(blackColor);
     app.activeDocument.selection.deselect();
 

--- a/public/js/photopea.js
+++ b/public/js/photopea.js
@@ -126,7 +126,7 @@ function translateIfNewLayerAdded(layerCount, bounds, scaleX, scaleY, layerName)
     const height = bounds[3] - bounds[1];
     const centerX = doc.width / 2;
     const centerY = doc.height / 2;
-    
+
     const imageLeft = centerX - width / 2;
     const imageTop = centerY - height / 2;
 
@@ -151,7 +151,12 @@ function cropSelectedRegion(maskBlur) {
     // Clear everything outside selection.
     doc.selection.invert();
     doc.selection.clear();
-    doc.selection.deselect();
+    app.echoToOE("success");
+}
+
+function deselect() {
+    app.activeDocument.selection.deselect();
+    app.echoToOE("success");
 }
 
 // Creates a black and white mask based on the current selection in the active document.

--- a/src/ImageUtil.ts
+++ b/src/ImageUtil.ts
@@ -250,9 +250,23 @@ function base64ArrayBuffer(arrayBuffer: ArrayBuffer): string {
     return base64
 }
 
+function getImageDimensions(imageURL: string): Promise<{ width: number; height: number; }> {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => { // using arrow function to keep 'this' context as 'img'
+            resolve({ width: img.width, height: img.height });
+        };
+        img.onerror = () => {
+            reject(new Error('Failed to load image'));
+        };
+        img.src = imageURL;
+    });
+}
+
 export {
     PayloadImage,
     applyMask,
     cropImage,
+    getImageDimensions,
     base64ArrayBuffer,
 }

--- a/src/ImageUtil.ts
+++ b/src/ImageUtil.ts
@@ -263,10 +263,42 @@ function getImageDimensions(imageURL: string): Promise<{ width: number; height: 
     });
 }
 
+async function resizeImage(imageURL: string, targetWidth: number, targetHeight: number): Promise<string> {
+    // Create a new fabric canvas
+    const canvas = new fabric.StaticCanvas(null, {
+        width: targetWidth,
+        height: targetHeight,
+    });
+
+    return new Promise((resolve, reject) => {
+        fabric.Image.fromURL(imageURL, (image) => {
+            // Scale factors for width and height
+            const scaleX = targetWidth / image.width!;
+            const scaleY = targetHeight / image.height!;
+
+            // Set scale for width and height separately
+            image.scaleX = scaleX;
+            image.scaleY = scaleY;
+
+            canvas.add(image);
+            canvas.renderAll();
+
+            // Create the resized image
+            const resizedBase64Image = canvas.toDataURL({
+                format: 'png',
+                quality: 1
+            });
+
+            resolve(resizedBase64Image);
+        });
+    });
+}
+
 export {
     PayloadImage,
     applyMask,
     cropImage,
     getImageDimensions,
+    resizeImage,
     base64ArrayBuffer,
 }

--- a/src/Photopea.ts
+++ b/src/Photopea.ts
@@ -182,10 +182,7 @@ class PhotopeaContext {
     }
 
     // Thread unsafe. Need be called within a task.
-    public async pasteImageOnPhotopea(
-        imageURL: string, bound: PhotopeaBound, scaleX: number, scaleY: number = scaleX,
-        layerName: string = 'image'
-    ) {
+    public async pasteImageOnPhotopea(imageURL: string, bound: PhotopeaBound,layerName: string = 'image') {
         const layerCount = Number(await this.invoke('pasteImageAsNewLayer', imageURL));
         console.debug(`sdp: Adding new layer. Num of top layers: ${layerCount}`);
 
@@ -196,7 +193,7 @@ class PhotopeaContext {
                     if (invokeInProgress) return;
                     invokeInProgress = true;
                     const status = await this.invoke(
-                        'translateIfNewLayerAdded', layerCount, bound, scaleX, scaleY, layerName);
+                        'translateIfNewLayerAdded', layerCount, bound, layerName);
                     if (status === 'success') {
                         console.debug(`sdp: New layer added. Done post process`);
                         clearInterval(waitTranslate);
@@ -214,9 +211,17 @@ class PhotopeaContext {
 };
 
 type PhotopeaBound = [number, number, number, number];
+function boundWidth(bound: PhotopeaBound) {
+    return bound[2] - bound[0];
+}
+function boundHeight(bound: PhotopeaBound) {
+    return bound[3] - bound[1];
+}
 
 const photopeaContext = new PhotopeaContext();
 export {
     type PhotopeaBound,
-    photopeaContext
+    boundWidth,
+    boundHeight,
+    photopeaContext,
 };

--- a/src/Photopea.ts
+++ b/src/Photopea.ts
@@ -183,10 +183,10 @@ class PhotopeaContext {
 
     // Thread unsafe. Need be called within a task.
     public async pasteImageOnPhotopea(
-        imageURL: string, left: number, top: number, width: number, height: number,
+        imageURL: string, bound: PhotopeaBound, scaleRatio: number,
         layerName: string = 'image'
     ) {
-        const layerCount = await this.invoke('pasteImageAsNewLayer', imageURL) as number;
+        const layerCount = Number(await this.invoke('pasteImageAsNewLayer', imageURL));
         console.debug(`sdp: Adding new layer. Num of top layers: ${layerCount}`);
 
         return new Promise((resolve, reject) => {
@@ -196,7 +196,7 @@ class PhotopeaContext {
                     if (invokeInProgress) return;
                     invokeInProgress = true;
                     const status = await this.invoke(
-                        'translateIfNewLayerAdded', layerCount, left, top, width, height, layerName);
+                        'translateIfNewLayerAdded', layerCount, bound, scaleRatio, layerName);
                     if (status === 'success') {
                         console.debug(`sdp: New layer added. Done post process`);
                         clearInterval(waitTranslate);

--- a/src/Photopea.ts
+++ b/src/Photopea.ts
@@ -183,7 +183,7 @@ class PhotopeaContext {
 
     // Thread unsafe. Need be called within a task.
     public async pasteImageOnPhotopea(
-        imageURL: string, bound: PhotopeaBound, scaleRatio: number,
+        imageURL: string, bound: PhotopeaBound, scaleX: number, scaleY: number = scaleX,
         layerName: string = 'image'
     ) {
         const layerCount = Number(await this.invoke('pasteImageAsNewLayer', imageURL));
@@ -196,7 +196,7 @@ class PhotopeaContext {
                     if (invokeInProgress) return;
                     invokeInProgress = true;
                     const status = await this.invoke(
-                        'translateIfNewLayerAdded', layerCount, bound, scaleRatio, layerName);
+                        'translateIfNewLayerAdded', layerCount, bound, scaleX, scaleY, layerName);
                     if (status === 'success') {
                         console.debug(`sdp: New layer added. Done post process`);
                         clearInterval(waitTranslate);

--- a/src/components/ControlNetUnit.vue
+++ b/src/components/ControlNetUnit.vue
@@ -210,7 +210,7 @@ export default {
                 const detectedMap = `data:image/png;base64,${data['images'][0]}`;
 
                 await photopeaContext.executeTask(async () => {
-                    await photopeaContext.pasteImageOnPhotopea(detectedMap, image.left, image.top, image.width, image.height);
+                    await photopeaContext.pasteImageOnPhotopea(detectedMap, bounds, /* scaleRatio= */1.0);
                     const previousLayerName = props.unit.linkedLayerName;
                     props.unit.linkedLayerName = `CN:${props.unit.module}:${hash}`;
                     await photopeaContext.invoke('controlNetDetectedMapPostProcess', props.unit.linkedLayerName, previousLayerName);

--- a/src/components/ControlNetUnit.vue
+++ b/src/components/ControlNetUnit.vue
@@ -5,8 +5,8 @@ import PayloadRadio from '@/components/PayloadRadio.vue';
 import { useA1111ContextStore } from '@/stores/a1111ContextStore';
 import { CloseOutlined, CheckOutlined, StopOutlined, CaretRightOutlined, UploadOutlined } from '@ant-design/icons-vue';
 import { computed, getCurrentInstance, ref, nextTick } from 'vue';
-import { photopeaContext, type PhotopeaBound } from '@/Photopea';
-import { PayloadImage, cropImage, getImageDimensions } from '@/ImageUtil';
+import { photopeaContext, type PhotopeaBound, boundWidth, boundHeight } from '@/Photopea';
+import { PayloadImage, cropImage, resizeImage } from '@/ImageUtil';
 import { useI18n } from 'vue-i18n';
 
 interface ModuleOption {
@@ -208,14 +208,11 @@ export default {
                     throw (data as ControlNetError).detail;
 
                 const detectedMap = `data:image/png;base64,${data['images'][0]}`;
-                const dims = await getImageDimensions(detectedMap);
-                const width = bounds[2] - bounds[0];
-                const height = bounds[3] - bounds[1];
-                const scaleX = dims.width / width;
-                const scaleY = dims.height / height;
-
                 await photopeaContext.executeTask(async () => {
-                    await photopeaContext.pasteImageOnPhotopea(detectedMap, bounds, scaleX, scaleY);
+                    await photopeaContext.pasteImageOnPhotopea(
+                        await resizeImage(detectedMap, boundWidth(bounds), boundHeight(bounds)), 
+                        bounds
+                    );
                     const previousLayerName = props.unit.linkedLayerName;
                     props.unit.linkedLayerName = `CN:${props.unit.module}:${hash}`;
                     await photopeaContext.invoke('controlNetDetectedMapPostProcess', props.unit.linkedLayerName, previousLayerName);

--- a/src/components/ControlNetUnit.vue
+++ b/src/components/ControlNetUnit.vue
@@ -6,7 +6,7 @@ import { useA1111ContextStore } from '@/stores/a1111ContextStore';
 import { CloseOutlined, CheckOutlined, StopOutlined, CaretRightOutlined, UploadOutlined } from '@ant-design/icons-vue';
 import { computed, getCurrentInstance, ref, nextTick } from 'vue';
 import { photopeaContext, type PhotopeaBound } from '@/Photopea';
-import { PayloadImage, cropImage } from '@/ImageUtil';
+import { PayloadImage, cropImage, getImageDimensions } from '@/ImageUtil';
 import { useI18n } from 'vue-i18n';
 
 interface ModuleOption {
@@ -208,9 +208,14 @@ export default {
                     throw (data as ControlNetError).detail;
 
                 const detectedMap = `data:image/png;base64,${data['images'][0]}`;
+                const dims = await getImageDimensions(detectedMap);
+                const width = bounds[2] - bounds[0];
+                const height = bounds[3] - bounds[1];
+                const scaleX = dims.width / width;
+                const scaleY = dims.height / height;
 
                 await photopeaContext.executeTask(async () => {
-                    await photopeaContext.pasteImageOnPhotopea(detectedMap, bounds, /* scaleRatio= */1.0);
+                    await photopeaContext.pasteImageOnPhotopea(detectedMap, bounds, scaleX, scaleY);
                     const previousLayerName = props.unit.linkedLayerName;
                     props.unit.linkedLayerName = `CN:${props.unit.module}:${hash}`;
                     await photopeaContext.invoke('controlNetDetectedMapPostProcess', props.unit.linkedLayerName, previousLayerName);

--- a/src/components/GenerationResultPicker.vue
+++ b/src/components/GenerationResultPicker.vue
@@ -69,7 +69,7 @@ export default {
         // Thead unsafe. Need to be called within task.
         async function selectResultImage(imageItem: ImageItem, layerName: string = 'ResultTempLayer') {
             await photopeaContext.pasteImageOnPhotopea(
-                imageItem.imageURL, props.bound! as PhotopeaBound, 
+                imageItem.imageURL, props.bound! as PhotopeaBound,
                 props.scaleRatio!, props.scaleRatio!, layerName
             );
         }
@@ -84,7 +84,9 @@ export default {
                 await deselectResultImage();
                 for (const image of selectedResultImages) {
                     await selectResultImage(image, /* layerName= */'ResultLayer');
+                    await photopeaContext.invoke('cropSelectedRegion', /* maskBlur=*/ 4);
                 }
+                await photopeaContext.invoke('deselect');
             });
             photopeaInProgress.value = false;
             finalizeSelection();

--- a/src/components/GenerationResultPicker.vue
+++ b/src/components/GenerationResultPicker.vue
@@ -21,10 +21,6 @@ export default {
             type: Array<number>,
             required: false,
         },
-        scaleRatio: {
-            type: Number,
-            required: false,
-        },
         maskBlur: {
             type: Number,
             required: false,

--- a/src/components/GenerationResultPicker.vue
+++ b/src/components/GenerationResultPicker.vue
@@ -24,6 +24,10 @@ export default {
             type: Number,
             required: false,
         },
+        maskBlur: {
+            type: Number,
+            required: false,
+        },
     },
     components: {
         ImagePicker,
@@ -84,7 +88,8 @@ export default {
                 await deselectResultImage();
                 for (const image of selectedResultImages) {
                     await selectResultImage(image, /* layerName= */'ResultLayer');
-                    await photopeaContext.invoke('cropSelectedRegion', /* maskBlur=*/ 4);
+                    console.log("sdp: Mask blur" + props.maskBlur);
+                    await photopeaContext.invoke('cropSelectedRegion', /* maskBlur=*/ props.maskBlur || 0);
                 }
                 await photopeaContext.invoke('deselect');
             });

--- a/src/components/GenerationResultPicker.vue
+++ b/src/components/GenerationResultPicker.vue
@@ -1,8 +1,9 @@
 <script lang="ts">
-import { photopeaContext, type PhotopeaBound } from '@/Photopea';
+import { photopeaContext, type PhotopeaBound, boundWidth, boundHeight } from '@/Photopea';
 import { computed, reactive, onMounted, ref, watch } from 'vue';
 import ImagePicker from './ImagePicker.vue';
 import { CloseOutlined, CheckOutlined } from '@ant-design/icons-vue';
+import { resizeImage } from '@/ImageUtil';
 
 interface ImageItem {
     imageURL: string;
@@ -72,9 +73,10 @@ export default {
         }
         // Thead unsafe. Need to be called within task.
         async function selectResultImage(imageItem: ImageItem, layerName: string = 'ResultTempLayer') {
+            const bound = props.bound! as PhotopeaBound;
             await photopeaContext.pasteImageOnPhotopea(
-                imageItem.imageURL, props.bound! as PhotopeaBound,
-                props.scaleRatio!, props.scaleRatio!, layerName
+                await resizeImage(imageItem.imageURL, boundWidth(bound), boundHeight(bound)),
+                bound, layerName
             );
         }
         function finalizeSelection() {

--- a/src/components/GenerationResultPicker.vue
+++ b/src/components/GenerationResultPicker.vue
@@ -69,7 +69,9 @@ export default {
         // Thead unsafe. Need to be called within task.
         async function selectResultImage(imageItem: ImageItem, layerName: string = 'ResultTempLayer') {
             await photopeaContext.pasteImageOnPhotopea(
-                imageItem.imageURL, props.bound! as PhotopeaBound, props.scaleRatio!, layerName);
+                imageItem.imageURL, props.bound! as PhotopeaBound, 
+                props.scaleRatio!, props.scaleRatio!, layerName
+            );
         }
         function finalizeSelection() {
             selectedResultImages.length = 0;

--- a/src/components/GenerationResultPicker.vue
+++ b/src/components/GenerationResultPicker.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { photopeaContext } from '@/Photopea';
+import { photopeaContext, type PhotopeaBound } from '@/Photopea';
 import { computed, reactive, onMounted, ref, watch } from 'vue';
 import ImagePicker from './ImagePicker.vue';
 import { CloseOutlined, CheckOutlined } from '@ant-design/icons-vue';
@@ -18,6 +18,10 @@ export default {
         },
         bound: {
             type: Array<number>,
+            required: false,
+        },
+        scaleRatio: {
+            type: Number,
             required: false,
         },
     },
@@ -64,11 +68,8 @@ export default {
         }
         // Thead unsafe. Need to be called within task.
         async function selectResultImage(imageItem: ImageItem, layerName: string = 'ResultTempLayer') {
-            const [left, top, right, bottom] = props.bound!;
-            const width = right - left;
-            const height = bottom - top;
             await photopeaContext.pasteImageOnPhotopea(
-                imageItem.imageURL, left, top, width, height, layerName);
+                imageItem.imageURL, props.bound! as PhotopeaBound, props.scaleRatio!, layerName);
         }
         function finalizeSelection() {
             selectedResultImages.length = 0;

--- a/src/views/GenerationView.vue
+++ b/src/views/GenerationView.vue
@@ -36,6 +36,7 @@ const generationActive = ref(false);
 
 // The bounding box to put the result image in.
 const resultImageBound = ref<PhotopeaBound | undefined>(undefined);
+const resultImageScaleRatio = ref<number | undefined>(undefined);
 
 const inputImageBuffer = ref<ArrayBuffer | undefined>(undefined);
 const inputMaskBuffer = ref<ArrayBuffer | undefined>(undefined);
@@ -203,6 +204,7 @@ async function preparePayload() {
         if (appState.generationMode === GenerationMode.Img2Img)
           expandSelectionBound(resultImageBound.value);
       }
+      resultImageScaleRatio.value = appState.imageScale;
 
       inputImageBuffer.value = await photopeaContext.invoke('exportAllLayers', /* format= */'PNG') as ArrayBuffer;
       inputMaskBuffer.value = await photopeaContext.invoke('exportMaskFromSelection', /* format= */'PNG') as ArrayBuffer;
@@ -227,8 +229,6 @@ async function preparePayload() {
 
     inputImage.value = image;
     inputMask.value = mask;
-
-    console.debug(`sdp: Result image bound: ${resultImageBound.value}`);
 
     const isImg2Img = appState.generationMode === GenerationMode.Img2Img;
     if (isImg2Img) {
@@ -423,7 +423,7 @@ const stepProgress = computed(() => {
               }}</a-button>
           </a-space>
         </a-form-item>
-        <GenerationResultPicker :imageURLs="resultImages" :bound="resultImageBound"
+        <GenerationResultPicker :imageURLs="resultImages" :bound="resultImageBound" :scaleRatio="resultImageScaleRatio"
           @result-finalized="onResultImagePicked">
         </GenerationResultPicker>
         <a-form-item>

--- a/src/views/GenerationView.vue
+++ b/src/views/GenerationView.vue
@@ -36,7 +36,6 @@ const generationActive = ref(false);
 
 // The bounding box to put the result image in.
 const resultImageBound = ref<PhotopeaBound | undefined>(undefined);
-const resultImageScaleRatio = ref<number | undefined>(undefined);
 const resultImageMaskBlur = ref<number | undefined>(undefined);
 
 const inputImageBuffer = ref<ArrayBuffer | undefined>(undefined);
@@ -221,7 +220,6 @@ async function preparePayload() {
     });
 
     resultImageBound.value = image.bound;
-    resultImageScaleRatio.value = appState.imageScale;
     if (appState.generationMode === GenerationMode.Img2Img) {
       resultImageMaskBlur.value = appState.img2imgPayload.mask_blur;
     }
@@ -340,7 +338,6 @@ async function generateWithConfig(configName: string) {
 
 function onResultImagePicked() {
   resultImageBound.value = undefined;
-  resultImageScaleRatio.value = undefined;
   resultImageMaskBlur.value = undefined;
   resultImages.length = 0;
   generationState.value = GenerationState.kInitialState;
@@ -436,8 +433,7 @@ const stepProgress = computed(() => {
               }}</a-button>
           </a-space>
         </a-form-item>
-        <GenerationResultPicker :imageURLs="resultImages" :bound="resultImageBound" :scaleRatio="resultImageScaleRatio"
-          :maskBlur="resultImageMaskBlur"
+        <GenerationResultPicker :imageURLs="resultImages" :bound="resultImageBound" :maskBlur="resultImageMaskBlur"
           @result-finalized="onResultImagePicked">
         </GenerationResultPicker>
         <a-form-item>

--- a/src/views/GenerationView.vue
+++ b/src/views/GenerationView.vue
@@ -37,6 +37,7 @@ const generationActive = ref(false);
 // The bounding box to put the result image in.
 const resultImageBound = ref<PhotopeaBound | undefined>(undefined);
 const resultImageScaleRatio = ref<number | undefined>(undefined);
+const resultImageMaskBlur = ref<number | undefined>(undefined);
 
 const inputImageBuffer = ref<ArrayBuffer | undefined>(undefined);
 const inputMaskBuffer = ref<ArrayBuffer | undefined>(undefined);
@@ -204,7 +205,6 @@ async function preparePayload() {
         if (appState.generationMode === GenerationMode.Img2Img)
           expandSelectionBound(resultImageBound.value);
       }
-      resultImageScaleRatio.value = appState.imageScale;
 
       inputImageBuffer.value = await photopeaContext.invoke('exportAllLayers', /* format= */'PNG') as ArrayBuffer;
       inputMaskBuffer.value = await photopeaContext.invoke('exportMaskFromSelection', /* format= */'PNG') as ArrayBuffer;
@@ -214,6 +214,11 @@ async function preparePayload() {
       ]);
       return [image, mask];
     });
+
+    resultImageScaleRatio.value = appState.imageScale;
+    if (appState.generationMode === GenerationMode.Img2Img) {
+      resultImageMaskBlur.value = appState.img2imgPayload.mask_blur;
+    }
 
     await setControlNetInputs(resultImageBound.value!);
     // Handling extension
@@ -329,6 +334,8 @@ async function generateWithConfig(configName: string) {
 
 function onResultImagePicked() {
   resultImageBound.value = undefined;
+  resultImageScaleRatio.value = undefined;
+  resultImageMaskBlur.value = undefined;
   resultImages.length = 0;
   generationState.value = GenerationState.kInitialState;
 }
@@ -424,6 +431,7 @@ const stepProgress = computed(() => {
           </a-space>
         </a-form-item>
         <GenerationResultPicker :imageURLs="resultImages" :bound="resultImageBound" :scaleRatio="resultImageScaleRatio"
+          :maskBlur="resultImageMaskBlur"
           @result-finalized="onResultImagePicked">
         </GenerationResultPicker>
         <a-form-item>


### PR DESCRIPTION
This PR fixes the boundary issue #1 by keep the selection active and crop out the reference area when final image is picked.

In order to implement this fix, the workflow of using `SelectRefArea` is reworked. Now clicking `SelectRefArea` will assume the first selection is the reference area, and selection selection is the inpaint area, which matches more to the button meaning.

Improved the pasteOnPhotopea logic, which will wait to fire another invoke when there is one active.