### PR TITLE
Fix generate more button triggered by toolbox buttons

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -11,10 +11,13 @@ function applyStateDiff(appState: ApplicationState, stateDiff: StateDiff): void 
         // Append controlnet units to appState instead of overwriting existing
         // units.
         if (_.isEqual(diffEntry.path, ['controlnetUnits']) &&
-            diffEntry.kind === 'A') {
-            diffEntry.index += appState.controlnetUnits.length;
+            diffEntry.kind === 'A' && diffEntry.item.kind === 'N') {
+            const indexShiftedEnetry = _.cloneDeep(diffEntry);
+            indexShiftedEnetry.index += appState.controlnetUnits.length;
+            applyChange(appState, undefined, indexShiftedEnetry);
+        } else {
+            applyChange(appState, undefined, diffEntry);
         }
-        applyChange(appState, undefined, diffEntry);
     });
     appState.controlnetUnits = appState.controlnetUnits.filter(u => !!u);
 }

--- a/src/views/GenerationView.vue
+++ b/src/views/GenerationView.vue
@@ -22,7 +22,7 @@ import { ReloadOutlined } from '@ant-design/icons-vue';
 import { useHistoryStore } from '@/stores/historyStore';
 import { useAppStateStore } from '@/stores/appStateStore';
 import { cloneNoBlob } from '@/Utils';
-import { DEFAULT_CONFIG, applyStateDiff } from '@/Config';
+import { DEFAULT_CONFIG, applyStateDiff, appStateToStateDiff } from '@/Config';
 import { useConfigStore } from '@/stores/configStore';
 import { CloseOutlined } from '@ant-design/icons-vue';
 
@@ -300,7 +300,7 @@ function resetPayload() {
 
   resultImageBound.value = undefined;
   resultImageMaskBlur.value = undefined;
-  
+
   for (const unit of appState.controlnetUnits) {
     // Only clear image when layer is linked.
     if (unit.linkedLayerName)
@@ -335,8 +335,9 @@ async function generateWithConfig(configName: string) {
   const stateDiff = configStore.configEntries[configName];
   const originalState = _.cloneDeep(appState);
   applyStateDiff(appState, stateDiff);
+  const undoDiff = appStateToStateDiff(/* toState */ originalState, /* fromState */ appState);
   await generate();
-  Object.assign(appState, originalState);
+  applyStateDiff(appState, undoDiff);
 }
 
 function onResultImagePicked() {

--- a/src/views/GenerationView.vue
+++ b/src/views/GenerationView.vue
@@ -323,7 +323,7 @@ function resetGenerationState() {
 }
 
 async function generate() {
-  if (generationState.value !== GenerationState.kPayloadPreparedState) {
+  if (generationState.value < GenerationState.kPayloadPreparedState) {
     const success = await preparePayload();
     if (!success) {
       return;


### PR DESCRIPTION
Closes #16.

This PR makes sure that when result is generated from a toolbox config, when clicking generate more button, the toolbox config is correctly applied for the generate more runs.