### PR TITLE
Support SD Ultimate Upscale Script

### DIFF
--- a/config_sharing/huchenlei_configs.json5
+++ b/config_sharing/huchenlei_configs.json5
@@ -172,7 +172,7 @@
             }
         }
     ],
-    "UltimateUpscale2x": {
+    "UltimateUpscale2x": [
         {
             "kind": "E",
             "path": ["img2imgPayload", "denoising_strength"],
@@ -181,23 +181,22 @@
         },
         {
             "kind": "E",
-            "path": ["commonPayload", "script_name"],
-            "lhs": null,
-            "rhs": "ultimate sd upscale",
+            "path": ["ultimateUpscale", "enabled"],
+            "lhs": false,
+            "rhs": true,
         },
         {
             "kind": "E",
-            "path": ["commonPayload", "script_args"],
-            "lhs": [],
-            // info, tile_width, tile_height, mask_blur, 
-            // padding, seams_fix_width, seams_fix_denoise, seams_fix_padding,
-            // upscaler_index, save_upscaled_image, redraw_mode, save_seams_fix_image, 
-            // seams_fix_mask_blur, seams_fix_type, target_size_type, custom_width,
-            // custom_height, custom_scale
-            "rhs": [
-                
-            ]
-        }
+            "path": ["ultimateUpscale", "upscaler_index"],
+            "lhs": 0,
+            "rhs": 6, // Anime6B
+        },
+        {
+            "kind": "E",
+            "path": ["ultimateUpscale", "custom_scale"],
+            "lhs": 1,
+            "rhs": 2,
+        },
         {
             "kind": "A",
             "path": [
@@ -226,6 +225,6 @@
                     "linkedLayerName": ""
                 }
             }
-        }
-    },
+        },
+    ],
 }

--- a/config_sharing/huchenlei_configs.json5
+++ b/config_sharing/huchenlei_configs.json5
@@ -172,7 +172,7 @@
             }
         }
     ],
-    "UltimateUpscale2x": [
+    "UltimateUpscaleAnime2x": [
         {
             "kind": "E",
             "path": ["img2imgPayload", "denoising_strength"],
@@ -196,6 +196,13 @@
             "path": ["ultimateUpscale", "custom_scale"],
             "lhs": 1,
             "rhs": 2,
+        },
+        // No inpaint reference.
+        {
+            "kind": "E",
+            "path": ["referenceRange"],
+            "lhs": [64, 10],
+            "rhs": [0, 0],
         },
         {
             "kind": "A",

--- a/config_sharing/huchenlei_configs.json5
+++ b/config_sharing/huchenlei_configs.json5
@@ -172,4 +172,60 @@
             }
         }
     ],
+    "UltimateUpscale2x": {
+        {
+            "kind": "E",
+            "path": ["img2imgPayload", "denoising_strength"],
+            "lhs": 0.75,
+            "rhs": 0.45,
+        },
+        {
+            "kind": "E",
+            "path": ["commonPayload", "script_name"],
+            "lhs": null,
+            "rhs": "ultimate sd upscale",
+        },
+        {
+            "kind": "E",
+            "path": ["commonPayload", "script_args"],
+            "lhs": [],
+            // info, tile_width, tile_height, mask_blur, 
+            // padding, seams_fix_width, seams_fix_denoise, seams_fix_padding,
+            // upscaler_index, save_upscaled_image, redraw_mode, save_seams_fix_image, 
+            // seams_fix_mask_blur, seams_fix_type, target_size_type, custom_width,
+            // custom_height, custom_scale
+            "rhs": [
+                
+            ]
+        }
+        {
+            "kind": "A",
+            "path": [
+                "controlnetUnits"
+            ],
+            "index": 0,
+            "item": {
+                "kind": "N",
+                "rhs": {
+                    "batch_images": "",
+                    "control_mode": 2,
+                    "enabled": true,
+                    "guidance_end": 1,
+                    "guidance_start": 0,
+                    "input_mode": 0,
+                    "low_vram": false,
+                    "model": "control_v11f1e_sd15_tile [a371b31b]",
+                    "module": "tile_colorfix",
+                    "output_dir": "",
+                    "pixel_perfect": false,
+                    "processor_res": 512,
+                    "resize_mode": 1,
+                    "threshold_a": 3,
+                    "threshold_b": 64,
+                    "weight": 1,
+                    "linkedLayerName": ""
+                }
+            }
+        }
+    },
 }

--- a/public/js/photopea.js
+++ b/public/js/photopea.js
@@ -105,6 +105,15 @@ function pasteImageAsNewLayer(base64image) {
     app.echoToOE(layerNumBeforePaste.toString());
 }
 
+/**
+ * Paste given image to Photopea as a new document.
+ * @param {string} base64image base64 string representing an image.
+ */
+function pasteImageAsNewDocument(base64image) {
+    app.open(base64image, null, /* asSmart */ false);
+    app.echoToOE('success');
+}
+
 // Translate the newly added layer if the new layer has been added.
 // Note: we cannot get layer bounds when a selection is active. So the resize and
 // translation are all based on payload calculations.

--- a/src/Automatic1111.ts
+++ b/src/Automatic1111.ts
@@ -280,6 +280,11 @@ interface IProgress {
     textinfo: string | null;
 };
 
+interface IScripts {
+    txt2img: string[];
+    img2img: string[];
+};
+
 async function fetchJSON(url: string): Promise<any> {
     const response = await fetch(url);
     return await response.json();
@@ -296,6 +301,7 @@ class A1111Context {
     sdVAEs: IStableDiffusionVAE[] = [];
     loras: ILoRA[] = [];
     options: IOptions = {} as IOptions;
+    scripts: IScripts = {} as IScripts;
 
     initialized: boolean = false;
 
@@ -310,6 +316,7 @@ class A1111Context {
             fetchJSON(`${this.apiURL}/embeddings`),
             fetchJSON(`${this.apiURL}/hypernetworks`),
             fetchJSON(`${this.apiURL}/options`),
+            fetchJSON(`${this.apiURL}/scripts`),
         ];
 
         const [
@@ -321,6 +328,7 @@ class A1111Context {
             embeddings,
             hypernetworks,
             options,
+            scripts,
         ] = await Promise.all(fetchPromises);
 
         this.samplers = samplers as ISampler[];
@@ -331,6 +339,7 @@ class A1111Context {
         this.embeddings = embeddings as IEmbeddings;
         this.hypernetworks = hypernetworks as IHypernetwork[];
         this.options = options as IOptions;
+        this.scripts = scripts as IScripts;
 
         this.initialized = true;
     }
@@ -398,7 +407,7 @@ interface ICommonPayload {
     s_noise: number;
     s_tmax: number | null;
     s_tmin: number;
-    script_args: string[];
+    script_args: any[];
     script_name: string | null;
     styles: string[];
     subseed_strength: number;
@@ -486,7 +495,7 @@ class CommonPayload implements ICommonPayload {
     s_noise: number = 1.0;
     s_tmax: number | null = null;
     s_tmin: number = 0.0;
-    script_args: string[] = [];
+    script_args: any[] = [];
     script_name: string | null = null;
     styles: string[] = [];
     alwayson_scripts: Record<string, IScriptDetail> = {};

--- a/src/Core.ts
+++ b/src/Core.ts
@@ -7,7 +7,8 @@ import {
     type ITxt2ImgPayload,
     Txt2ImgPayload,
 } from './Automatic1111';
-import { ControlNetUnit, type IControlNetUnit } from './ControlNet';
+import { type IControlNetUnit } from './ControlNet';
+import { UltimateUpscaleScript, type IUltimateUpscaleScript } from './UltimateUpscale';
 
 enum ReferenceRangeMode {
     kPixel,
@@ -46,6 +47,8 @@ interface IApplicationState {
     // Extensions
     // ControlNet
     controlnetUnits: IControlNetUnit[];
+    // UltimateUpscale
+    ultimateUpscale: IUltimateUpscaleScript;
 };
 
 interface IHistoryItem {
@@ -64,6 +67,7 @@ class ApplicationState implements IApplicationState {
     subseedStrength: number = 0.15;
     imageResultDestination: ImageResultDestination = ImageResultDestination.kCurrentCanvas;
     controlnetUnits: IControlNetUnit[] = [];
+    ultimateUpscale: IUltimateUpscaleScript = new UltimateUpscaleScript();
 };
 
 export {

--- a/src/Core.ts
+++ b/src/Core.ts
@@ -14,6 +14,11 @@ enum ReferenceRangeMode {
     kPercent,
 };
 
+enum ImageResultDestination {
+    kCurrentCanvas,
+    kNewCanvas,
+};
+
 /**
  * The application state that can be saved and load to UI later.
  */
@@ -35,6 +40,9 @@ interface IApplicationState {
     // Subseed strength. The subseed strength used when clicking `generate with more variants`
     subseedStrength: number;
 
+    // Image result destination.
+    imageResultDestination: ImageResultDestination;
+
     // Extensions
     // ControlNet
     controlnetUnits: IControlNetUnit[];
@@ -54,6 +62,7 @@ class ApplicationState implements IApplicationState {
     referenceRange: [number, number] = [64, 10];
     referenceRangeMode: ReferenceRangeMode = ReferenceRangeMode.kPixel;
     subseedStrength: number = 0.15;
+    imageResultDestination: ImageResultDestination = ImageResultDestination.kCurrentCanvas;
     controlnetUnits: IControlNetUnit[] = [];
 };
 
@@ -62,4 +71,5 @@ export {
     type IHistoryItem,
     ApplicationState,
     ReferenceRangeMode,
+    ImageResultDestination,
 };

--- a/src/Photopea.ts
+++ b/src/Photopea.ts
@@ -182,7 +182,7 @@ class PhotopeaContext {
     }
 
     // Thread unsafe. Need be called within a task.
-    public async pasteImageOnPhotopea(imageURL: string, bound: PhotopeaBound,layerName: string = 'image') {
+    public async pasteImageOnPhotopea(imageURL: string, bound: PhotopeaBound, layerName: string = 'image') {
         const layerCount = Number(await this.invoke('pasteImageAsNewLayer', imageURL));
         console.debug(`sdp: Adding new layer. Num of top layers: ${layerCount}`);
 

--- a/src/UltimateUpscale.ts
+++ b/src/UltimateUpscale.ts
@@ -1,20 +1,20 @@
 enum RedrawMode {
-    kLinear = 0,
-    kChess = 1,
-    kNone = 2,
+    Linear = 0,
+    Chess = 1,
+    None = 2,
 };
 
 enum SeamFixType {
-    kNone = 0,
-    kBandPass = 1,
-    kHalfTile = 2,
-    kHalfTilePlusIntersections = 3,
+    None = 0,
+    BandPass = 1,
+    HalfTile = 2,
+    HalfTilePlusIntersections = 3,
 };
 
 enum TargetSizeType {
-    kFromImg2ImgSettings,
-    kCustomSize,
-    kScaleFromImageSize,
+    FromImg2ImgSettings,
+    CustomSize,
+    ScaleFromImageSize,
 };
 
 interface IUltimateUpscaleScript {
@@ -63,11 +63,11 @@ class UltimateUpscaleScript implements IUltimateUpscaleScript {
     seams_fix_padding: number = 32;
     upscaler_index: number = 0;
     save_upscaled_image: boolean = true;
-    redraw_mode: RedrawMode = RedrawMode.kLinear;
+    redraw_mode: RedrawMode = RedrawMode.Linear;
     save_seams_fix_image: boolean = false;
     seams_fix_mask_blur: number = 8;
-    seams_fix_type: SeamFixType = SeamFixType.kNone;
-    target_size_type: TargetSizeType = TargetSizeType.kScaleFromImageSize;
+    seams_fix_type: SeamFixType = SeamFixType.None;
+    target_size_type: TargetSizeType = TargetSizeType.ScaleFromImageSize;
     custom_width: number = 2048;
     custom_height: number = 2048;
     custom_scale: number = 2;

--- a/src/UltimateUpscale.ts
+++ b/src/UltimateUpscale.ts
@@ -1,0 +1,82 @@
+enum RedrawMode {
+    kLinear = 0,
+    kChess = 1,
+    kNone = 2,
+};
+
+enum SeamFixType {
+    kNone = 0,
+    kBandPass = 1,
+    kHalfTile = 2,
+    kHalfTilePlusIntersections = 3,
+};
+
+enum TargetSizeType {
+    kFromImg2ImgSettings,
+    kCustomSize,
+    kScaleFromImageSize,
+};
+
+interface IUltimateUpscaleScript {
+    enabled: boolean;
+    info: string;
+    tile_width: number;
+    tile_height: number;
+    mask_blur: number;
+    padding: number;
+    seams_fix_width: number;
+    seams_fix_denoise: number;
+    seams_fix_padding: number;
+    upscaler_index: number;
+    save_upscaled_image: boolean;
+    redraw_mode: RedrawMode;
+    save_seams_fix_image: boolean;
+    seams_fix_mask_blur: number;
+    seams_fix_type: SeamFixType;
+    target_size_type: TargetSizeType;
+    custom_width: number;
+    custom_height: number;
+    custom_scale: number;
+};
+
+class UltimateUpscaleScript implements IUltimateUpscaleScript {
+    static readonly script_name: string = "ultimate sd upscale";
+    static script_args(self: IUltimateUpscaleScript) {
+        return [
+            self.info, self.tile_width, self.tile_height, self.mask_blur,
+            self.padding, self.seams_fix_width, self.seams_fix_denoise, self.seams_fix_padding,
+            self.upscaler_index, self.save_upscaled_image, self.redraw_mode, self.save_seams_fix_image,
+            self.seams_fix_mask_blur, self.seams_fix_type, self.target_size_type, self.custom_width,
+            self.custom_height, self.custom_scale
+        ];
+    }
+
+    enabled: boolean = false;
+
+    info: string = "Will upscale the image depending on the selected target size type";
+    tile_width: number = 512;
+    tile_height: number = 512;
+    mask_blur: number = 8;
+    padding: number = 32;
+    seams_fix_width: number = 64;
+    seams_fix_denoise: number = 0.35;
+    seams_fix_padding: number = 32;
+    upscaler_index: number = 0;
+    save_upscaled_image: boolean = true;
+    redraw_mode: RedrawMode = RedrawMode.kLinear;
+    save_seams_fix_image: boolean = false;
+    seams_fix_mask_blur: number = 8;
+    seams_fix_type: SeamFixType = SeamFixType.kNone;
+    target_size_type: TargetSizeType = TargetSizeType.kScaleFromImageSize;
+    custom_width: number = 2048;
+    custom_height: number = 2048;
+    custom_scale: number = 2;
+};
+
+export {
+    RedrawMode,
+    SeamFixType,
+    TargetSizeType,
+    type IUltimateUpscaleScript,
+    UltimateUpscaleScript,
+};

--- a/src/components/UltimateUpscale.vue
+++ b/src/components/UltimateUpscale.vue
@@ -1,0 +1,104 @@
+<script lang="ts">
+import { computed } from 'vue';
+import { useA1111ContextStore } from '@/stores/a1111ContextStore';
+import SliderGroup from './SliderGroup.vue';
+import { UltimateUpscaleScript, SeamFixType, RedrawMode } from '@/UltimateUpscale';
+import { CheckOutlined, StopOutlined } from '@ant-design/icons-vue';
+import PayloadRadio from './PayloadRadio.vue';
+
+export default {
+    name: 'UltimateUpscale',
+    props: {
+        script: {
+            type: UltimateUpscaleScript,
+            required: true,
+        },
+    },
+    components: {
+        SliderGroup,
+        PayloadRadio,
+        CheckOutlined,
+        StopOutlined,
+    },
+    emits: ['update:prompt', 'append:prompt'],
+    setup(props, { emit }) {
+        const context = useA1111ContextStore().a1111Context;
+        const upscalers = computed(() => {
+            return context.upscalers.map(u => u.name);
+        });
+
+        function toggleScriptEnabled() {
+            // TODO: inform GenerationView about enable change if we are adding
+            // more supported script later.
+            props.script.enabled = !props.script.enabled;
+        }
+
+        return {
+            upscalers,
+            SeamFixType,
+            RedrawMode,
+            toggleScriptEnabled,
+        };
+    },
+};
+</script>
+
+<template>
+    <a-collapse :bordered="false">
+        <a-collapse-panel>
+            <template #header>
+                <a-space>
+                    <a-button type="dashed" :danger="!$props.script.enabled" size="small" @click.stop="toggleScriptEnabled">
+                        <CheckOutlined v-if="$props.script.enabled"></CheckOutlined>
+                        <StopOutlined v-else></StopOutlined>
+                    </a-button>
+                    <span>Ultimate Upscale</span>
+                </a-space>
+            </template>
+            <a-space direction="vertical">
+                <SliderGroup :label="$t('gen.scaleRatio')" v-model:value="$props.script.custom_scale" :min="1" :max="16"
+                    :log-scale="true"></SliderGroup>
+
+                <a-row>
+                    <a-tag class="label">Upscaler:</a-tag>
+                    <a-radio-group v-model:value="$props.script.upscaler_index" size="small">
+                        <a-radio-button v-for="(upscaler, i) in upscalers" :key="i" :value="i">
+                            {{ upscaler }}
+                        </a-radio-button>
+                    </a-radio-group>
+                </a-row>
+
+                <PayloadRadio v-model:value="$props.script.redraw_mode" :enum-type="RedrawMode"
+                    :label="$t('upscale.redrawMode')">
+                </PayloadRadio>
+                <SliderGroup :label="$t('upscale.tileWidth')" v-model:value="$props.script.tile_width" :min="0" :max="2048"
+                    :log-scale="true"></SliderGroup>
+                <SliderGroup :label="$t('upscale.tileHeight')" v-model:value="$props.script.tile_height" :min="0"
+                    :max="2048" :log-scale="true"></SliderGroup>
+                <SliderGroup :label="$t('upscale.maskBlur')" v-model:value="$props.script.mask_blur" :min="0" :max="64"
+                    :log-scale="true"></SliderGroup>
+                <SliderGroup :label="$t('upscale.padding')" v-model:value="$props.script.padding" :min="0" :max="128"
+                    :log-scale="true"></SliderGroup>
+
+                <PayloadRadio v-model:value="$props.script.seams_fix_type" :enum-type="SeamFixType"
+                    :label="$t('upscale.seamFixType')">
+                </PayloadRadio>
+                <SliderGroup :label="$t('upscale.seamfix.denoise')" v-model:value="$props.script.seams_fix_denoise" :min="0"
+                    :max="1" :step="0.05"></SliderGroup>
+                <SliderGroup :label="$t('upscale.seamfix.width')" v-model:value="$props.script.seams_fix_width" :min="0"
+                    :max="128" :log-scale="true"></SliderGroup>
+                <SliderGroup :label="$t('upscale.seamfix.padding')" v-model:value="$props.script.seams_fix_padding" :min="0"
+                    :max="128" :log-scale="true"></SliderGroup>
+                <SliderGroup :label="$t('upscale.seamfix.mask_blur')" v-model:value="$props.script.seams_fix_mask_blur"
+                    :min="0" :max="64" :log-scale="true"></SliderGroup>
+            </a-space>
+        </a-collapse-panel>
+    </a-collapse>
+</template>
+
+<style scoped>
+.label {
+    border: none;
+}
+</style>
+

--- a/src/components/UltimateUpscale.vue
+++ b/src/components/UltimateUpscale.vue
@@ -83,15 +83,15 @@ export default {
                 <PayloadRadio v-model:value="$props.script.seams_fix_type" :enum-type="SeamFixType"
                     :label="$t('upscale.seamFixType')">
                 </PayloadRadio>
-                <SliderGroup v-if="$props.script.seams_fix_type !== SeamFixType.kNone"
+                <SliderGroup v-if="$props.script.seams_fix_type !== SeamFixType.None"
                     :label="$t('upscale.seamfix.denoise')" v-model:value="$props.script.seams_fix_denoise" :min="0" :max="1"
                     :step="0.05"></SliderGroup>
-                <SliderGroup v-if="$props.script.seams_fix_type !== SeamFixType.kNone" :label="$t('upscale.seamfix.width')"
+                <SliderGroup v-if="$props.script.seams_fix_type !== SeamFixType.None" :label="$t('upscale.seamfix.width')"
                     v-model:value="$props.script.seams_fix_width" :min="0" :max="128" :log-scale="true"></SliderGroup>
-                <SliderGroup v-if="$props.script.seams_fix_type !== SeamFixType.kNone"
+                <SliderGroup v-if="$props.script.seams_fix_type !== SeamFixType.None"
                     :label="$t('upscale.seamfix.padding')" v-model:value="$props.script.seams_fix_padding" :min="0"
                     :max="128" :log-scale="true"></SliderGroup>
-                <SliderGroup v-if="$props.script.seams_fix_type !== SeamFixType.kNone"
+                <SliderGroup v-if="$props.script.seams_fix_type !== SeamFixType.None"
                     :label="$t('upscale.seamfix.mask_blur')" v-model:value="$props.script.seams_fix_mask_blur" :min="0"
                     :max="64" :log-scale="true"></SliderGroup>
             </a-space>

--- a/src/components/UltimateUpscale.vue
+++ b/src/components/UltimateUpscale.vue
@@ -60,7 +60,7 @@ export default {
                     :log-scale="true"></SliderGroup>
 
                 <a-row>
-                    <a-tag class="label">Upscaler:</a-tag>
+                    <a-tag class="label">{{ $t('upscale.upscaler') }}:</a-tag>
                     <a-radio-group v-model:value="$props.script.upscaler_index" size="small">
                         <a-radio-button v-for="(upscaler, i) in upscalers" :key="i" :value="i">
                             {{ upscaler }}
@@ -83,14 +83,17 @@ export default {
                 <PayloadRadio v-model:value="$props.script.seams_fix_type" :enum-type="SeamFixType"
                     :label="$t('upscale.seamFixType')">
                 </PayloadRadio>
-                <SliderGroup :label="$t('upscale.seamfix.denoise')" v-model:value="$props.script.seams_fix_denoise" :min="0"
-                    :max="1" :step="0.05"></SliderGroup>
-                <SliderGroup :label="$t('upscale.seamfix.width')" v-model:value="$props.script.seams_fix_width" :min="0"
+                <SliderGroup v-if="$props.script.seams_fix_type !== SeamFixType.kNone"
+                    :label="$t('upscale.seamfix.denoise')" v-model:value="$props.script.seams_fix_denoise" :min="0" :max="1"
+                    :step="0.05"></SliderGroup>
+                <SliderGroup v-if="$props.script.seams_fix_type !== SeamFixType.kNone" :label="$t('upscale.seamfix.width')"
+                    v-model:value="$props.script.seams_fix_width" :min="0" :max="128" :log-scale="true"></SliderGroup>
+                <SliderGroup v-if="$props.script.seams_fix_type !== SeamFixType.kNone"
+                    :label="$t('upscale.seamfix.padding')" v-model:value="$props.script.seams_fix_padding" :min="0"
                     :max="128" :log-scale="true"></SliderGroup>
-                <SliderGroup :label="$t('upscale.seamfix.padding')" v-model:value="$props.script.seams_fix_padding" :min="0"
-                    :max="128" :log-scale="true"></SliderGroup>
-                <SliderGroup :label="$t('upscale.seamfix.mask_blur')" v-model:value="$props.script.seams_fix_mask_blur"
-                    :min="0" :max="64" :log-scale="true"></SliderGroup>
+                <SliderGroup v-if="$props.script.seams_fix_type !== SeamFixType.kNone"
+                    :label="$t('upscale.seamfix.mask_blur')" v-model:value="$props.script.seams_fix_mask_blur" :min="0"
+                    :max="64" :log-scale="true"></SliderGroup>
             </a-space>
         </a-collapse-panel>
     </a-collapse>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -71,6 +71,21 @@ const messages = {
             overwritePrompt: 'Overwrite Prompt',
             appendPrompt: 'Append Prompt',
         },
+        upscale: {
+            upscaler: 'Upscaler',
+            redrawMode: 'Redraw Mode',
+            tileWidth: 'Tile Width',
+            tileHeight: 'Tile Height',
+            maskBlur: 'Mask Blur',
+            padding: 'Padding',
+            seamFixType: 'Seam Fix Type',
+            seamfix: {
+                denoise: 'Seam Fix Denoise Strength',
+                width: 'Seam Fix Width',
+                padding: 'Seam Fix Padding',
+                maskBlur: 'Seam Fix Mask Blur',
+            },
+        },
 
         weight: 'Weight',
         width: 'Width',

--- a/src/views/ConfigView.vue
+++ b/src/views/ConfigView.vue
@@ -35,7 +35,7 @@
             {{ $t('config.download') }}</a-button>
         </a-col>
         <a-col :span="12">
-          <a-upload accept="application/json" :beforeUpload="uploadConfig" :showUploadList="false"
+          <a-upload :beforeUpload="uploadConfig" :showUploadList="false"
             style="display: block;">
             <a-button :title="$t('config.uploadConfig')" style="width: 100%;"><upload-outlined></upload-outlined> {{
               $t('config.upload')

--- a/src/views/GenerationView.vue
+++ b/src/views/GenerationView.vue
@@ -464,8 +464,8 @@ const stepProgress = computed(() => {
           </a-space>
         </a-form-item>
         <GenerationResultPicker :images="resultImages" :bound="resultImageBound" :maskBlur="resultImageMaskBlur"
-          @result-finalized="onResultImagePicked" @generate-more="generateMore"
-          @generate-more-variants="generateMoreVariants">
+          :result-destination="appState.imageResultDestination" @result-finalized="onResultImagePicked"
+          @generate-more="generateMore" @generate-more-variants="generateMoreVariants">
         </GenerationResultPicker>
         <a-form-item>
           <SliderGroup :label="$t('gen.scaleRatio')" v-model:value="appState.imageScale" :min="1" :max="16"

--- a/src/views/GenerationView.vue
+++ b/src/views/GenerationView.vue
@@ -287,9 +287,11 @@ async function sendPayload() {
     });
     const result = await response.json() as IGenerationResult;
 
-    const controlNetCount = _.sum(appState.controlnetUnits.map(unit => unit.enabled ? 1 : 0));
-    // Remove controlnet maps from image results.
-    const imageURLs = (controlNetCount > 0 ? result.images.slice(0, -controlNetCount) : result.images)
+    // Expected number of images from generation.
+    // ControlNet maps appending at the end will be dropped.
+    const numImages = appState.ultimateUpscale.enabled ? 1 : 
+      appState.commonPayload.batch_size * appState.commonPayload.n_iter;
+    const imageURLs = result.images.slice(0, numImages)
       .map((image: string) => `data:image/png;base64,${image}`);
 
     const info = JSON.parse(result.info) as IGenerationInfo;
@@ -492,7 +494,7 @@ const stepProgress = computed(() => {
           <div v-if="appState.referenceRangeMode === ReferenceRangeMode.kPixel"
             style="display:flex; align-items: center; width: 100%">
             <a-button @click="appState.referenceRangeMode = ReferenceRangeMode.kPercent">px</a-button>
-            <SliderGroup :label="$t('gen.referenceRange')" v-model:value="appState.referenceRange[0]" :min="1" :max="256"
+            <SliderGroup :label="$t('gen.referenceRange')" v-model:value="appState.referenceRange[0]" :min="0" :max="256"
               :log-scale="true">
             </SliderGroup>
           </div>


### PR DESCRIPTION
Closes https://github.com/huchenlei/stable-diffusion-ps-pea/issues/14
Now the dropping of controlnet maps are based on number of expected images from the generation. So users with both options on/off should all have no problem using the plugin.

Closes https://github.com/huchenlei/stable-diffusion-ps-pea/issues/8.
Now you can invoke SD Ultimate Upscale script just like how you do it in A1111. The upscaled image will be pasted to a new document in Photopea. I also provide a configuration `UltimateUpscaleAnime2x`, which suits my normal upscale workflow. Feel free to adjust params there to suit your own workflow.
